### PR TITLE
Remove border when use on button tag

### DIFF
--- a/src/obvious-buttons.css
+++ b/src/obvious-buttons.css
@@ -9,6 +9,7 @@
   display: block;
   text-align: center;
   cursor: pointer;
+  border: none;
   height: 40px;
   padding: 0 14px;
   border-radius: 5px;

--- a/src/obvious-buttons.less
+++ b/src/obvious-buttons.less
@@ -114,6 +114,7 @@
   display: block;
   text-align: center;
   cursor: pointer;
+  border: none;
   .buttonSize(40px, 3px, 18px);
   .transition(background-color, 0.2s);
 


### PR DESCRIPTION
Set border to none to disable default borders of button tag on new browsers.
