### PR TITLE
Optimize LESS code for smaller CSS footprint

### DIFF
--- a/src/obvious-buttons.css
+++ b/src/obvious-buttons.css
@@ -18,8 +18,6 @@
   box-shadow: inset 0 -3px 0 0 rgba(0, 0, 0, 0.15);
   font-size: 18px;
   line-height: 37px;
-  background: #fafafa;
-  color: #222222;
   -webkit-transition-property: background-color;
   -webkit-transition-duration: 0.2s;
   -webkit-transition-timing-function: linear;
@@ -35,10 +33,7 @@
   transition-property: background-color;
   transition-duration: 0.2s;
   transition-timing-function: linear;
-}
-.button:hover,
-.button:focus {
-  background: #e6e6e6;
+  background: #fafafa;
   color: #222222;
 }
 .button i {
@@ -48,10 +43,22 @@
 .button:active i {
   line-height: 40px;
 }
-.button.button-primary {
+.button.button-primary,
+.button.button-info,
+.button.button-success,
+.button.button-warning,
+.button.button-danger,
+.button.button-inverse {
   -webkit-box-shadow: inset 0 -3px 0 0 rgba(0, 0, 0, 0.2);
   -moz-box-shadow: inset 0 -3px 0 0 rgba(0, 0, 0, 0.2);
   box-shadow: inset 0 -3px 0 0 rgba(0, 0, 0, 0.2);
+}
+.button:hover,
+.button:focus {
+  background: #e6e6e6;
+  color: #222222;
+}
+.button.button-primary {
   background: #0088cc;
   color: #fafafa;
 }
@@ -61,9 +68,6 @@
   color: #fafafa;
 }
 .button.button-info {
-  -webkit-box-shadow: inset 0 -3px 0 0 rgba(0, 0, 0, 0.2);
-  -moz-box-shadow: inset 0 -3px 0 0 rgba(0, 0, 0, 0.2);
-  box-shadow: inset 0 -3px 0 0 rgba(0, 0, 0, 0.2);
   background: #49afcd;
   color: #fafafa;
 }
@@ -73,9 +77,6 @@
   color: #fafafa;
 }
 .button.button-success {
-  -webkit-box-shadow: inset 0 -3px 0 0 rgba(0, 0, 0, 0.2);
-  -moz-box-shadow: inset 0 -3px 0 0 rgba(0, 0, 0, 0.2);
-  box-shadow: inset 0 -3px 0 0 rgba(0, 0, 0, 0.2);
   background: #5bb75b;
   color: #fafafa;
 }
@@ -85,9 +86,6 @@
   color: #fafafa;
 }
 .button.button-warning {
-  -webkit-box-shadow: inset 0 -3px 0 0 rgba(0, 0, 0, 0.2);
-  -moz-box-shadow: inset 0 -3px 0 0 rgba(0, 0, 0, 0.2);
-  box-shadow: inset 0 -3px 0 0 rgba(0, 0, 0, 0.2);
   background: #faa732;
   color: #fafafa;
 }
@@ -97,9 +95,6 @@
   color: #fafafa;
 }
 .button.button-danger {
-  -webkit-box-shadow: inset 0 -3px 0 0 rgba(0, 0, 0, 0.2);
-  -moz-box-shadow: inset 0 -3px 0 0 rgba(0, 0, 0, 0.2);
-  box-shadow: inset 0 -3px 0 0 rgba(0, 0, 0, 0.2);
   background: #da4f49;
   color: #fafafa;
 }
@@ -109,9 +104,6 @@
   color: #fafafa;
 }
 .button.button-inverse {
-  -webkit-box-shadow: inset 0 -3px 0 0 rgba(0, 0, 0, 0.2);
-  -moz-box-shadow: inset 0 -3px 0 0 rgba(0, 0, 0, 0.2);
-  box-shadow: inset 0 -3px 0 0 rgba(0, 0, 0, 0.2);
   background: #363636;
   color: #fafafa;
 }
@@ -144,13 +136,6 @@
   box-shadow: inset 0 -2px 0 0 rgba(0, 0, 0, 0.15);
   font-size: 14px;
   line-height: 28px;
-  background: #fafafa;
-  color: #222222;
-}
-.button-small:hover,
-.button-small:focus {
-  background: #e6e6e6;
-  color: #222222;
 }
 .button-small i {
   line-height: 28px;
@@ -159,77 +144,15 @@
 .button-small:active i {
   line-height: 30px;
 }
-.button-small.button-primary {
-  -webkit-box-shadow: inset 0 -2px 0 0 rgba(0, 0, 0, 0.2);
-  -moz-box-shadow: inset 0 -2px 0 0 rgba(0, 0, 0, 0.2);
-  box-shadow: inset 0 -2px 0 0 rgba(0, 0, 0, 0.2);
-  background: #0088cc;
-  color: #fafafa;
-}
-.button-small.button-primary:hover,
-.button-small.button-primary:focus {
-  background: #006da3;
-  color: #fafafa;
-}
-.button-small.button-info {
-  -webkit-box-shadow: inset 0 -2px 0 0 rgba(0, 0, 0, 0.2);
-  -moz-box-shadow: inset 0 -2px 0 0 rgba(0, 0, 0, 0.2);
-  box-shadow: inset 0 -2px 0 0 rgba(0, 0, 0, 0.2);
-  background: #49afcd;
-  color: #fafafa;
-}
-.button-small.button-info:hover,
-.button-small.button-info:focus {
-  background: #339bba;
-  color: #fafafa;
-}
-.button-small.button-success {
-  -webkit-box-shadow: inset 0 -2px 0 0 rgba(0, 0, 0, 0.2);
-  -moz-box-shadow: inset 0 -2px 0 0 rgba(0, 0, 0, 0.2);
-  box-shadow: inset 0 -2px 0 0 rgba(0, 0, 0, 0.2);
-  background: #5bb75b;
-  color: #fafafa;
-}
-.button-small.button-success:hover,
-.button-small.button-success:focus {
-  background: #47a247;
-  color: #fafafa;
-}
-.button-small.button-warning {
-  -webkit-box-shadow: inset 0 -2px 0 0 rgba(0, 0, 0, 0.2);
-  -moz-box-shadow: inset 0 -2px 0 0 rgba(0, 0, 0, 0.2);
-  box-shadow: inset 0 -2px 0 0 rgba(0, 0, 0, 0.2);
-  background: #faa732;
-  color: #fafafa;
-}
-.button-small.button-warning:hover,
-.button-small.button-warning:focus {
-  background: #f9960a;
-  color: #fafafa;
-}
-.button-small.button-danger {
-  -webkit-box-shadow: inset 0 -2px 0 0 rgba(0, 0, 0, 0.2);
-  -moz-box-shadow: inset 0 -2px 0 0 rgba(0, 0, 0, 0.2);
-  box-shadow: inset 0 -2px 0 0 rgba(0, 0, 0, 0.2);
-  background: #da4f49;
-  color: #fafafa;
-}
-.button-small.button-danger:hover,
-.button-small.button-danger:focus {
-  background: #d0312a;
-  color: #fafafa;
-}
+.button-small.button-primary,
+.button-small.button-info,
+.button-small.button-success,
+.button-small.button-warning,
+.button-small.button-danger,
 .button-small.button-inverse {
   -webkit-box-shadow: inset 0 -2px 0 0 rgba(0, 0, 0, 0.2);
   -moz-box-shadow: inset 0 -2px 0 0 rgba(0, 0, 0, 0.2);
   box-shadow: inset 0 -2px 0 0 rgba(0, 0, 0, 0.2);
-  background: #363636;
-  color: #fafafa;
-}
-.button-small.button-inverse:hover,
-.button-small.button-inverse:focus {
-  background: #222222;
-  color: #fafafa;
 }
 .button-large {
   height: 50px;
@@ -240,13 +163,6 @@
   box-shadow: inset 0 -4px 0 0 rgba(0, 0, 0, 0.15);
   font-size: 22px;
   line-height: 46px;
-  background: #fafafa;
-  color: #222222;
-}
-.button-large:hover,
-.button-large:focus {
-  background: #e6e6e6;
-  color: #222222;
 }
 .button-large i {
   line-height: 46px;
@@ -255,77 +171,15 @@
 .button-large:active i {
   line-height: 50px;
 }
-.button-large.button-primary {
-  -webkit-box-shadow: inset 0 -4px 0 0 rgba(0, 0, 0, 0.2);
-  -moz-box-shadow: inset 0 -4px 0 0 rgba(0, 0, 0, 0.2);
-  box-shadow: inset 0 -4px 0 0 rgba(0, 0, 0, 0.2);
-  background: #0088cc;
-  color: #fafafa;
-}
-.button-large.button-primary:hover,
-.button-large.button-primary:focus {
-  background: #006da3;
-  color: #fafafa;
-}
-.button-large.button-info {
-  -webkit-box-shadow: inset 0 -4px 0 0 rgba(0, 0, 0, 0.2);
-  -moz-box-shadow: inset 0 -4px 0 0 rgba(0, 0, 0, 0.2);
-  box-shadow: inset 0 -4px 0 0 rgba(0, 0, 0, 0.2);
-  background: #49afcd;
-  color: #fafafa;
-}
-.button-large.button-info:hover,
-.button-large.button-info:focus {
-  background: #339bba;
-  color: #fafafa;
-}
-.button-large.button-success {
-  -webkit-box-shadow: inset 0 -4px 0 0 rgba(0, 0, 0, 0.2);
-  -moz-box-shadow: inset 0 -4px 0 0 rgba(0, 0, 0, 0.2);
-  box-shadow: inset 0 -4px 0 0 rgba(0, 0, 0, 0.2);
-  background: #5bb75b;
-  color: #fafafa;
-}
-.button-large.button-success:hover,
-.button-large.button-success:focus {
-  background: #47a247;
-  color: #fafafa;
-}
-.button-large.button-warning {
-  -webkit-box-shadow: inset 0 -4px 0 0 rgba(0, 0, 0, 0.2);
-  -moz-box-shadow: inset 0 -4px 0 0 rgba(0, 0, 0, 0.2);
-  box-shadow: inset 0 -4px 0 0 rgba(0, 0, 0, 0.2);
-  background: #faa732;
-  color: #fafafa;
-}
-.button-large.button-warning:hover,
-.button-large.button-warning:focus {
-  background: #f9960a;
-  color: #fafafa;
-}
-.button-large.button-danger {
-  -webkit-box-shadow: inset 0 -4px 0 0 rgba(0, 0, 0, 0.2);
-  -moz-box-shadow: inset 0 -4px 0 0 rgba(0, 0, 0, 0.2);
-  box-shadow: inset 0 -4px 0 0 rgba(0, 0, 0, 0.2);
-  background: #da4f49;
-  color: #fafafa;
-}
-.button-large.button-danger:hover,
-.button-large.button-danger:focus {
-  background: #d0312a;
-  color: #fafafa;
-}
+.button-large.button-primary,
+.button-large.button-info,
+.button-large.button-success,
+.button-large.button-warning,
+.button-large.button-danger,
 .button-large.button-inverse {
   -webkit-box-shadow: inset 0 -4px 0 0 rgba(0, 0, 0, 0.2);
   -moz-box-shadow: inset 0 -4px 0 0 rgba(0, 0, 0, 0.2);
   box-shadow: inset 0 -4px 0 0 rgba(0, 0, 0, 0.2);
-  background: #363636;
-  color: #fafafa;
-}
-.button-large.button-inverse:hover,
-.button-large.button-inverse:focus {
-  background: #222222;
-  color: #fafafa;
 }
 .button-xlarge {
   height: 60px;
@@ -336,13 +190,6 @@
   box-shadow: inset 0 -5px 0 0 rgba(0, 0, 0, 0.15);
   font-size: 26px;
   line-height: 55px;
-  background: #fafafa;
-  color: #222222;
-}
-.button-xlarge:hover,
-.button-xlarge:focus {
-  background: #e6e6e6;
-  color: #222222;
 }
 .button-xlarge i {
   line-height: 55px;
@@ -351,77 +198,15 @@
 .button-xlarge:active i {
   line-height: 60px;
 }
-.button-xlarge.button-primary {
-  -webkit-box-shadow: inset 0 -5px 0 0 rgba(0, 0, 0, 0.2);
-  -moz-box-shadow: inset 0 -5px 0 0 rgba(0, 0, 0, 0.2);
-  box-shadow: inset 0 -5px 0 0 rgba(0, 0, 0, 0.2);
-  background: #0088cc;
-  color: #fafafa;
-}
-.button-xlarge.button-primary:hover,
-.button-xlarge.button-primary:focus {
-  background: #006da3;
-  color: #fafafa;
-}
-.button-xlarge.button-info {
-  -webkit-box-shadow: inset 0 -5px 0 0 rgba(0, 0, 0, 0.2);
-  -moz-box-shadow: inset 0 -5px 0 0 rgba(0, 0, 0, 0.2);
-  box-shadow: inset 0 -5px 0 0 rgba(0, 0, 0, 0.2);
-  background: #49afcd;
-  color: #fafafa;
-}
-.button-xlarge.button-info:hover,
-.button-xlarge.button-info:focus {
-  background: #339bba;
-  color: #fafafa;
-}
-.button-xlarge.button-success {
-  -webkit-box-shadow: inset 0 -5px 0 0 rgba(0, 0, 0, 0.2);
-  -moz-box-shadow: inset 0 -5px 0 0 rgba(0, 0, 0, 0.2);
-  box-shadow: inset 0 -5px 0 0 rgba(0, 0, 0, 0.2);
-  background: #5bb75b;
-  color: #fafafa;
-}
-.button-xlarge.button-success:hover,
-.button-xlarge.button-success:focus {
-  background: #47a247;
-  color: #fafafa;
-}
-.button-xlarge.button-warning {
-  -webkit-box-shadow: inset 0 -5px 0 0 rgba(0, 0, 0, 0.2);
-  -moz-box-shadow: inset 0 -5px 0 0 rgba(0, 0, 0, 0.2);
-  box-shadow: inset 0 -5px 0 0 rgba(0, 0, 0, 0.2);
-  background: #faa732;
-  color: #fafafa;
-}
-.button-xlarge.button-warning:hover,
-.button-xlarge.button-warning:focus {
-  background: #f9960a;
-  color: #fafafa;
-}
-.button-xlarge.button-danger {
-  -webkit-box-shadow: inset 0 -5px 0 0 rgba(0, 0, 0, 0.2);
-  -moz-box-shadow: inset 0 -5px 0 0 rgba(0, 0, 0, 0.2);
-  box-shadow: inset 0 -5px 0 0 rgba(0, 0, 0, 0.2);
-  background: #da4f49;
-  color: #fafafa;
-}
-.button-xlarge.button-danger:hover,
-.button-xlarge.button-danger:focus {
-  background: #d0312a;
-  color: #fafafa;
-}
+.button-xlarge.button-primary,
+.button-xlarge.button-info,
+.button-xlarge.button-success,
+.button-xlarge.button-warning,
+.button-xlarge.button-danger,
 .button-xlarge.button-inverse {
   -webkit-box-shadow: inset 0 -5px 0 0 rgba(0, 0, 0, 0.2);
   -moz-box-shadow: inset 0 -5px 0 0 rgba(0, 0, 0, 0.2);
   box-shadow: inset 0 -5px 0 0 rgba(0, 0, 0, 0.2);
-  background: #363636;
-  color: #fafafa;
-}
-.button-xlarge.button-inverse:hover,
-.button-xlarge.button-inverse:focus {
-  background: #222222;
-  color: #fafafa;
 }
 .button-inline {
   display: inline-block;

--- a/src/obvious-buttons.less
+++ b/src/obvious-buttons.less
@@ -29,6 +29,7 @@
 @inverse-background-color: #363636;
 @inverse-text-color: #fafafa;
 
+
 // Cross-browser helpers
 
 .boxShadow (@statement) {
@@ -74,7 +75,6 @@
   .boxShadow(inset 0 -@depth 0 0 rgba(0, 0, 0, 0.15));
   font-size: @font-size;
   line-height: @height - @depth;
-  .buttonColor(@default-background-color, @default-text-color);
 
   i {
     line-height: @height - @depth;
@@ -82,30 +82,8 @@
   &:active, &:active i {
     line-height: @height;
   }
-
-  &.button-primary {
+  &.button-primary, &.button-info, &.button-success, &.button-warning, &.button-danger, &.button-inverse {
     .boxShadow(inset 0 -@depth 0 0 rgba(0, 0, 0, 0.2));
-    .buttonColor(@primary-background-color, @primary-text-color);
-  }
-  &.button-info {
-    .boxShadow(inset 0 -@depth 0 0 rgba(0, 0, 0, 0.2));
-    .buttonColor(@info-background-color, @info-text-color);
-  }
-  &.button-success {
-    .boxShadow(inset 0 -@depth 0 0 rgba(0, 0, 0, 0.2));
-    .buttonColor(@success-background-color, @success-text-color);
-  }
-  &.button-warning {
-    .boxShadow(inset 0 -@depth 0 0 rgba(0, 0, 0, 0.2));
-    .buttonColor(@warning-background-color, @warning-text-color);
-  }
-  &.button-danger {
-    .boxShadow(inset 0 -@depth 0 0 rgba(0, 0, 0, 0.2));
-    .buttonColor(@danger-background-color, @danger-text-color);
-  }
-  &.button-inverse {
-    .boxShadow(inset 0 -@depth 0 0 rgba(0, 0, 0, 0.2));
-    .buttonColor(@inverse-background-color, @inverse-text-color);
   }
 }
 
@@ -117,6 +95,26 @@
   border: none;
   .buttonSize(40px, 3px, 18px);
   .transition(background-color, 0.2s);
+  .buttonColor(@default-background-color, @default-text-color);
+
+  &.button-primary {
+    .buttonColor(@primary-background-color, @primary-text-color);
+  }
+  &.button-info {
+    .buttonColor(@info-background-color, @info-text-color);
+  }
+  &.button-success {
+    .buttonColor(@success-background-color, @success-text-color);
+  }
+  &.button-warning {
+    .buttonColor(@warning-background-color, @warning-text-color);
+  }
+  &.button-danger {
+    .buttonColor(@danger-background-color, @danger-text-color);
+  }
+  &.button-inverse {
+    .buttonColor(@inverse-background-color, @inverse-text-color);
+  }
 
   span {
     // We need this extra span because there's a WebKit bug that sometimes


### PR DESCRIPTION
If you take a look at the CSS that's being generated by the current LESS code, you'll see that there's a lot of repetition going on. For example the [base button](https://github.com/skidding/obvious-buttons/blob/master/src/obvious-buttons.css#L39-#L43) `background` and `color` get applied to [every](https://github.com/skidding/obvious-buttons/blob/master/src/obvious-buttons.css#L150-#L153) [other](https://github.com/skidding/obvious-buttons/blob/master/src/obvious-buttons.css#L246-#L250) [button](https://github.com/skidding/obvious-buttons/blob/master/src/obvious-buttons.css#L342-#L346) size.

By setting the button `color` and `background-color` inside the `.button` class an not in the `.buttonSize` mixin, I was a able to do away with much of that repetition. 
Another thing was to merge button type selectors that couldn't be taken out of `.buttonSize` due to their reliance on `@depth`.

``` css
  &.button-primary, &.button-info, &.button-success, &.button-warning, &.button-danger, &.button-inverse {
    .boxShadow(inset 0 -@depth 0 0 rgba(0, 0, 0, 0.2));
  }
```

With these changes the outputted CSS will only be 214 lines vs 429 lines in the original version.
