### PR TITLE
Update for Bootstrap v3.1+

### DIFF
--- a/demo/script/index.js
+++ b/demo/script/index.js
@@ -2,7 +2,7 @@ $(function() {
   new Dragdealer('flat-slider');
 
   var globalCounter = 0;
-  $('.button').click(function(e) {
+  $('.btn').click(function(e) {
     e.preventDefault();
     $('.global-counter').text(++globalCounter);
   });

--- a/index.html
+++ b/index.html
@@ -31,52 +31,52 @@
   </div>
 
   <div class="buttons top-space">
-    <h3>.button-small</h3>
-    <a href="#nada" class="button button-inline button-small"><span>click me</span></a><a
-       href="#nada" class="button button-inline button-small button-primary"><span>click me</span></a><a
-       href="#nada" class="button button-inline button-small button-info"><span>click me</span></a><a
-       href="#nada" class="button button-inline button-small button-success"><span>click me</span></a><a
-       href="#nada" class="button button-inline button-small button-warning"><span>click me</span></a><a
-       href="#nada" class="button button-inline button-small button-danger"><span>click me</span></a><a
-       href="#nada" class="button button-inline button-small button-inverse"><span>click me</span></a>
-    <h3>.button</h3>
-    <a href="#nada" class="button button-inline"><span>click me</span></a><a
-       href="#nada" class="button button-inline button-primary"><span>click me</span></a><a
-       href="#nada" class="button button-inline button-info"><span>click me</span></a><a
-       href="#nada" class="button button-inline button-success"><span>click me</span></a><a
-       href="#nada" class="button button-inline button-warning"><span>click me</span></a><a
-       href="#nada" class="button button-inline button-danger"><span>click me</span></a><a
-       href="#nada" class="button button-inline button-inverse"><span>click me</span></a>
-    <h3>.button-large</h3>
-    <a href="#nada" class="button button-inline button-large"><span>click me</span></a><a
-       href="#nada" class="button button-inline button-large button-primary"><span>click me</span></a><a
-       href="#nada" class="button button-inline button-large button-info"><span>click me</span></a><a
-       href="#nada" class="button button-inline button-large button-success"><span>click me</span></a><a
-       href="#nada" class="button button-inline button-large button-warning"><span>click me</span></a><a
-       href="#nada" class="button button-inline button-large button-danger"><span>click me</span></a><a
-       href="#nada" class="button button-inline button-large button-inverse"><span>click me</span></a>
-    <h3>.button-xlarge</h3>
-    <a href="#nada" class="button button-inline button-xlarge"><span><em>lick</em> me</span></a><a
-       href="#nada" class="button button-inline button-xlarge button-primary"><span><em>lick</em> me</span></a><a
-       href="#nada" class="button button-inline button-xlarge button-info"><span><em>lick</em> me</span></a><a
-       href="#nada" class="button button-inline button-xlarge button-success"><span><em>lick</em> me</span></a><a
-       href="#nada" class="button button-inline button-xlarge button-warning"><span><em>lick</em> me</span></a><a
-       href="#nada" class="button button-inline button-xlarge button-danger"><span><em>lick</em> me</span></a><a
-       href="#nada" class="button button-inline button-xlarge button-inverse"><span><em>lick</em> me</span></a>
+    <h3>.btn-small</h3>
+    <a href="#nada" class="btn btn-inline btn-small"><span>click me</span></a><a
+       href="#nada" class="btn btn-inline btn-small btn-primary"><span>click me</span></a><a
+       href="#nada" class="btn btn-inline btn-small btn-info"><span>click me</span></a><a
+       href="#nada" class="btn btn-inline btn-small btn-success"><span>click me</span></a><a
+       href="#nada" class="btn btn-inline btn-small btn-warning"><span>click me</span></a><a
+       href="#nada" class="btn btn-inline btn-small btn-danger"><span>click me</span></a><a
+       href="#nada" class="btn btn-inline btn-small btn-inverse"><span>click me</span></a>
+    <h3>.btn</h3>
+    <a href="#nada" class="btn btn-inline"><span>click me</span></a><a
+       href="#nada" class="btn btn-inline btn-primary"><span>click me</span></a><a
+       href="#nada" class="btn btn-inline btn-info"><span>click me</span></a><a
+       href="#nada" class="btn btn-inline btn-success"><span>click me</span></a><a
+       href="#nada" class="btn btn-inline btn-warning"><span>click me</span></a><a
+       href="#nada" class="btn btn-inline btn-danger"><span>click me</span></a><a
+       href="#nada" class="btn btn-inline btn-inverse"><span>click me</span></a>
+    <h3>.btn-large</h3>
+    <a href="#nada" class="btn btn-inline btn-large"><span>click me</span></a><a
+       href="#nada" class="btn btn-inline btn-large btn-primary"><span>click me</span></a><a
+       href="#nada" class="btn btn-inline btn-large btn-info"><span>click me</span></a><a
+       href="#nada" class="btn btn-inline btn-large btn-success"><span>click me</span></a><a
+       href="#nada" class="btn btn-inline btn-large btn-warning"><span>click me</span></a><a
+       href="#nada" class="btn btn-inline btn-large btn-danger"><span>click me</span></a><a
+       href="#nada" class="btn btn-inline btn-large btn-inverse"><span>click me</span></a>
+    <h3>.btn-xlarge</h3>
+    <a href="#nada" class="btn btn-inline btn-xlarge"><span><em>lick</em> me</span></a><a
+       href="#nada" class="btn btn-inline btn-xlarge btn-primary"><span><em>lick</em> me</span></a><a
+       href="#nada" class="btn btn-inline btn-xlarge btn-info"><span><em>lick</em> me</span></a><a
+       href="#nada" class="btn btn-inline btn-xlarge btn-success"><span><em>lick</em> me</span></a><a
+       href="#nada" class="btn btn-inline btn-xlarge btn-warning"><span><em>lick</em> me</span></a><a
+       href="#nada" class="btn btn-inline btn-xlarge btn-danger"><span><em>lick</em> me</span></a><a
+       href="#nada" class="btn btn-inline btn-xlarge btn-inverse"><span><em>lick</em> me</span></a>
   </div>
 
   <h2>They work great with <a href="http://fontawesome.io">FontAwesome</a></h2>
   <div class="buttons">
-    <a href="#nada" class="button button-inline"><span><i class="fa fa-home"></i></span></a><a
-       href="#nada" class="button button-inline"><span><i class="fa fa-bar-chart-o"></i> click me</span></a><a
-       href="#nada" class="button button-inline"><span>click me <i class="fa fa-music"></i> </span></a><a
-       href="#nada" class="button button-inline"><span>click <i class="fa fa-globe"></i> me</span></a>
+    <a href="#nada" class="btn btn-inline"><span><i class="fa fa-home"></i></span></a><a
+       href="#nada" class="btn btn-inline"><span><i class="fa fa-bar-chart-o"></i> click me</span></a><a
+       href="#nada" class="btn btn-inline"><span>click me <i class="fa fa-music"></i> </span></a><a
+       href="#nada" class="btn btn-inline"><span>click <i class="fa fa-globe"></i> me</span></a>
   </div>
 
   <h2>Shameless plug: <a href="https://github.com/skidding/dragdealer">Dragdealer.js</a> integration</h2>
   <div class="left-align">
     <div id="flat-slider" class="dragdealer">
-      <div class="handle button button-large button-danger"><span>drag me</span></div>
+      <div class="handle btn btn-large btn-danger"><span>drag me</span></div>
     </div>
   </div>
 

--- a/src/obvious-buttons.css
+++ b/src/obvious-buttons.css
@@ -5,7 +5,7 @@
  * (c) 2014+ Ovidiu Cherecheș
  * http://skidding.mit-license.org
  */
-.button {
+.btn {
   display: block;
   text-align: center;
   cursor: pointer;
@@ -36,98 +36,98 @@
   background: #fafafa;
   color: #222222;
 }
-.button i {
+.btn i {
   line-height: 37px;
 }
-.button:active,
-.button:active i {
+.btn:active,
+.btn:active i {
   line-height: 40px;
 }
-.button.button-primary,
-.button.button-info,
-.button.button-success,
-.button.button-warning,
-.button.button-danger,
-.button.button-inverse {
+.btn.btn-primary,
+.btn.btn-info,
+.btn.btn-success,
+.btn.btn-warning,
+.btn.btn-danger,
+.btn.btn-inverse {
   -webkit-box-shadow: inset 0 -3px 0 0 rgba(0, 0, 0, 0.2);
   -moz-box-shadow: inset 0 -3px 0 0 rgba(0, 0, 0, 0.2);
   box-shadow: inset 0 -3px 0 0 rgba(0, 0, 0, 0.2);
 }
-.button:hover,
-.button:focus {
+.btn:hover,
+.btn:focus {
   background: #e6e6e6;
   color: #222222;
 }
-.button.button-primary {
+.btn.btn-primary {
   background: #0088cc;
   color: #fafafa;
 }
-.button.button-primary:hover,
-.button.button-primary:focus {
+.btn.btn-primary:hover,
+.btn.btn-primary:focus {
   background: #006da3;
   color: #fafafa;
 }
-.button.button-info {
+.btn.btn-info {
   background: #49afcd;
   color: #fafafa;
 }
-.button.button-info:hover,
-.button.button-info:focus {
+.btn.btn-info:hover,
+.btn.btn-info:focus {
   background: #339bba;
   color: #fafafa;
 }
-.button.button-success {
+.btn.btn-success {
   background: #5bb75b;
   color: #fafafa;
 }
-.button.button-success:hover,
-.button.button-success:focus {
+.btn.btn-success:hover,
+.btn.btn-success:focus {
   background: #47a247;
   color: #fafafa;
 }
-.button.button-warning {
+.btn.btn-warning {
   background: #faa732;
   color: #fafafa;
 }
-.button.button-warning:hover,
-.button.button-warning:focus {
+.btn.btn-warning:hover,
+.btn.btn-warning:focus {
   background: #f9960a;
   color: #fafafa;
 }
-.button.button-danger {
+.btn.btn-danger {
   background: #da4f49;
   color: #fafafa;
 }
-.button.button-danger:hover,
-.button.button-danger:focus {
+.btn.btn-danger:hover,
+.btn.btn-danger:focus {
   background: #d0312a;
   color: #fafafa;
 }
-.button.button-inverse {
+.btn.btn-inverse {
   background: #363636;
   color: #fafafa;
 }
-.button.button-inverse:hover,
-.button.button-inverse:focus {
+.btn.btn-inverse:hover,
+.btn.btn-inverse:focus {
   background: #222222;
   color: #fafafa;
 }
-.button span {
+.btn span {
   pointer-events: none;
 }
-.button:hover {
+.btn:hover {
   text-decoration: none;
 }
-.button:focus {
+.btn:focus {
   text-decoration: none;
   outline: none;
 }
-.button:active {
+.btn:active {
   -webkit-box-shadow: none !important;
   -moz-box-shadow: none !important;
   box-shadow: none !important;
 }
-.button-small {
+.btn-small {
   height: 30px;
   padding: 0 10px;
   border-radius: 4px;
@@ -137,24 +137,24 @@
   font-size: 14px;
   line-height: 28px;
 }
-.button-small i {
+.btn-small i {
   line-height: 28px;
 }
-.button-small:active,
-.button-small:active i {
+.btn-small:active,
+.btn-small:active i {
   line-height: 30px;
 }
-.button-small.button-primary,
-.button-small.button-info,
-.button-small.button-success,
-.button-small.button-warning,
-.button-small.button-danger,
-.button-small.button-inverse {
+.btn-small.btn-primary,
+.btn-small.btn-info,
+.btn-small.btn-success,
+.btn-small.btn-warning,
+.btn-small.btn-danger,
+.btn-small.btn-inverse {
   -webkit-box-shadow: inset 0 -2px 0 0 rgba(0, 0, 0, 0.2);
   -moz-box-shadow: inset 0 -2px 0 0 rgba(0, 0, 0, 0.2);
   box-shadow: inset 0 -2px 0 0 rgba(0, 0, 0, 0.2);
 }
-.button-large {
+.btn-large {
   height: 50px;
   padding: 0 18px;
   border-radius: 6px;
@@ -164,24 +164,24 @@
   font-size: 22px;
   line-height: 46px;
 }
-.button-large i {
+.btn-large i {
   line-height: 46px;
 }
-.button-large:active,
-.button-large:active i {
+.btn-large:active,
+.btn-large:active i {
   line-height: 50px;
 }
-.button-large.button-primary,
-.button-large.button-info,
-.button-large.button-success,
-.button-large.button-warning,
-.button-large.button-danger,
-.button-large.button-inverse {
+.btn-large.btn-primary,
+.btn-large.btn-info,
+.btn-large.btn-success,
+.btn-large.btn-warning,
+.btn-large.btn-danger,
+.btn-large.btn-inverse {
   -webkit-box-shadow: inset 0 -4px 0 0 rgba(0, 0, 0, 0.2);
   -moz-box-shadow: inset 0 -4px 0 0 rgba(0, 0, 0, 0.2);
   box-shadow: inset 0 -4px 0 0 rgba(0, 0, 0, 0.2);
 }
-.button-xlarge {
+.btn-xlarge {
   height: 60px;
   padding: 0 22px;
   border-radius: 7px;
@@ -191,24 +191,24 @@
   font-size: 26px;
   line-height: 55px;
 }
-.button-xlarge i {
+.btn-xlarge i {
   line-height: 55px;
 }
-.button-xlarge:active,
-.button-xlarge:active i {
+.btn-xlarge:active,
+.btn-xlarge:active i {
   line-height: 60px;
 }
-.button-xlarge.button-primary,
-.button-xlarge.button-info,
-.button-xlarge.button-success,
-.button-xlarge.button-warning,
-.button-xlarge.button-danger,
-.button-xlarge.button-inverse {
+.btn-xlarge.btn-primary,
+.btn-xlarge.btn-info,
+.btn-xlarge.btn-success,
+.btn-xlarge.btn-warning,
+.btn-xlarge.btn-danger,
+.btn-xlarge.btn-inverse {
   -webkit-box-shadow: inset 0 -5px 0 0 rgba(0, 0, 0, 0.2);
   -moz-box-shadow: inset 0 -5px 0 0 rgba(0, 0, 0, 0.2);
   box-shadow: inset 0 -5px 0 0 rgba(0, 0, 0, 0.2);
 }
-.button-inline {
+.btn-inline {
   display: inline-block;
   vertical-align: middle;
 }

--- a/src/obvious-buttons.less
+++ b/src/obvious-buttons.less
@@ -82,13 +82,13 @@
   &:active, &:active i {
     line-height: @height;
   }
-  &.button-primary, &.button-info, &.button-success, &.button-warning, &.button-danger, &.button-inverse {
+  &.btn-primary, &.btn-info, &.btn-success, &.btn-warning, &.btn-danger, &.btn-inverse {
     .boxShadow(inset 0 -@depth 0 0 rgba(0, 0, 0, 0.2));
   }
 }
 
-.button {
-  // Add .button-inline class for inline-block display
+.btn {
+  // Add .btn-inline class for inline-block display
   display: block;
   text-align: center;
   cursor: pointer;
@@ -97,22 +97,22 @@
   .transition(background-color, 0.2s);
   .buttonColor(@default-background-color, @default-text-color);
 
-  &.button-primary {
+  &.btn-primary {
     .buttonColor(@primary-background-color, @primary-text-color);
   }
-  &.button-info {
+  &.btn-info {
     .buttonColor(@info-background-color, @info-text-color);
   }
-  &.button-success {
+  &.btn-success {
     .buttonColor(@success-background-color, @success-text-color);
   }
-  &.button-warning {
+  &.btn-warning {
     .buttonColor(@warning-background-color, @warning-text-color);
   }
-  &.button-danger {
+  &.btn-danger {
     .buttonColor(@danger-background-color, @danger-text-color);
   }
-  &.button-inverse {
+  &.btn-inverse {
     .buttonColor(@inverse-background-color, @inverse-text-color);
   }
 
@@ -136,18 +136,18 @@
     .boxShadow(~"none !important");
   }
 }
-.button-small {
+.btn-small {
   .buttonSize(30px, 2px, 14px);
 }
-.button-large {
+.btn-large {
   .buttonSize(50px, 4px, 22px);
 }
-.button-xlarge {
+.btn-xlarge {
   .buttonSize(60px, 5px, 26px);
 }
 
 
-.button-inline {
+.btn-inline {
   display: inline-block;
   vertical-align: middle;
 }


### PR DESCRIPTION
Replace “button” classes with “btn” classes for use with Bootstrap v3.1+
